### PR TITLE
Make TravisCI run with headless chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ before_install:
  - echo 'Europe/Bratislava' | sudo tee /etc/timezone
  - sudo dpkg-reconfigure --frontend noninteractive tzdata
  - export CHROME_BIN=/usr/bin/google-chrome
- - export DISPLAY=:99.0
- - sh -e /etc/init.d/xvfb start
  - sudo apt-get update
  - sudo apt-get install -y libappindicator1 fonts-liberation
  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb

--- a/gulp/e2e-tests.js
+++ b/gulp/e2e-tests.js
@@ -19,7 +19,11 @@ function runProtractor (done) {
 
   gulp.src(path.join(conf.paths.e2e, '/**/*.spec.js'))
     .pipe($.protractor.protractor({
-      configFile: 'protractor.conf.js',
+      configFile: (
+        !process.env.TRAVIS
+        ? 'protractor.conf.js'
+        : 'protractor-headless.conf.js'
+      ),
       args: args
     }))
     .on('error', function (err) {

--- a/protractor-headless.conf.js
+++ b/protractor-headless.conf.js
@@ -1,0 +1,15 @@
+// https://angular.io/guide/testing#configure-cli-for-ci-testing-in-chrome
+const config = require('./protractor.conf').config;
+config.capabilities = {
+  browserName: 'chrome',
+  chromeOptions: {
+     args: [
+       "--headless",
+       "--disable-gpu",
+       "--no-sandbox",
+       "--disable-dev-shm-usage",
+       "--window-size=800,600"
+     ]
+  }
+};
+exports.config = config;


### PR DESCRIPTION
TravisCI fails with

```
$ sh -e /etc/init.d/xvfb start
sh: 0: Can't open /etc/init.d/xvfb
The command "sh -e /etc/init.d/xvfb start" failed and exited with 127 during .
Your build has been stopped.
```

`xvfb` seems used for the virtual desktop environment for Chrome, and I propose to use headless Chrome instead.
